### PR TITLE
Update sandbox URLs

### DIFF
--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,9 +1,11 @@
+from django.conf.urls import i18n
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 from oscar.app import application
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path(r'', application.urls),
+    path('i18n/', include(i18n)),
+    path('', application.urls),
 ]


### PR DESCRIPTION
* Without `i18n/` will be raised:
```
Reverse for 'set_language' not found. 'set_language' is not a valid view function or pattern name.
```