### PR TITLE
 Fix attr name typo in `__str__` method of `AbstractInvoice` model

### DIFF
--- a/oscar_invoices/abstract_models.py
+++ b/oscar_invoices/abstract_models.py
@@ -102,4 +102,4 @@ class AbstractInvoice(models.Model):
             ) % {'invoice_number': self.number, 'order_number': order_number}
 
         return _(
-            'Invoice %(invoice_number)s') % {'number': self.number}
+            'Invoice %(invoice_number)s') % {'invoice_number': self.number}

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         'phonenumbers',
         'pillow',
-        'django>=1.11',
+        'django>=1.11,<2.2',
         'django-oscar>=1.6',
         'django-phonenumber-field>=2.0,<2.1',
     ],

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -4,7 +4,6 @@ from datetime import date
 from mock import patch
 
 from django.conf import settings
-from django.test import override_settings
 
 from oscar.core.loading import get_model
 from oscar.test.testcases import WebTestCase


### PR DESCRIPTION
Refs: #10 