### PR TITLE
Remove upper bound pins that are allready present in oscar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
     install_requires=[
         'phonenumbers',
         'pillow',
-        'django>=1.11,<4.0',
+        'django>=1.11',
         'django-oscar>=2.0',
-        'django-phonenumber-field>=3.0.0,<6.0.0',
+        'django-phonenumber-field>=3.0.0',
     ]
 )


### PR DESCRIPTION
When oscar updates a dependency the pins in oscar-invoices hinder the operation of oscar-invoices with the newer oscar version.